### PR TITLE
Refactor NonEmptyString to module pattern; fix Vitest coverage

### DIFF
--- a/config/eslint/eslint.config.js
+++ b/config/eslint/eslint.config.js
@@ -1,11 +1,11 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
+import importPlugin from 'eslint-plugin-import';
 import eslintPluginPrettier from 'eslint-plugin-prettier';
 import eslintConfigPrettier from 'eslint-config-prettier';
 import typescriptEslintParser from '@typescript-eslint/parser';
 import typescriptEslintPlugin from '@typescript-eslint/eslint-plugin';
 import prettierConfig from '../../config/prettier/.prettierrc.json' with { type: 'json' };
-import importPlugin from 'eslint-plugin-import';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '../../');
@@ -14,7 +14,7 @@ const tsConfigPath = path.resolve(projectRoot, 'tsconfig.json');
 export default [
   {
     files: ['**/*.ts', '**/*.tsx'],
-    ignores: ['node_modules/', 'dist/', 'build/', 'config/vite/vite-env.d.ts'],
+    ignores: ['node_modules/', 'coverage/', 'dist/', 'build/', 'config/vite/vite-env.d.ts'],
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'module',

--- a/config/vite/vite.config.ts
+++ b/config/vite/vite.config.ts
@@ -72,10 +72,10 @@ export default defineConfig({
     exclude: ['**/node_modules/**'],
     coverage: {
       all: true,
-      enabled: false,
+      enabled: true,
       provider: 'v8',
       skipFull: true,
-      reportsDirectory: './coverage',
+      reportsDirectory: 'coverage',
       reporter: ['text', 'json', 'html'],
       include: ['src/**/*.ts', 'src/**/*.tsx'],
       exclude: [

--- a/config/vite/vite.config.ts
+++ b/config/vite/vite.config.ts
@@ -72,7 +72,7 @@ export default defineConfig({
     exclude: ['**/node_modules/**'],
     coverage: {
       all: true,
-      enabled: true,
+      enabled: false,
       provider: 'v8',
       skipFull: true,
       reportsDirectory: './coverage',

--- a/config/vite/vite.config.ts
+++ b/config/vite/vite.config.ts
@@ -7,7 +7,7 @@ const projectRoot = path.resolve(__dirname, '../../');
 
 export default defineConfig({
   base: '/extrasolar/',
-  root: path.resolve(projectRoot, 'src/presentation/client'),
+  root: projectRoot,
   publicDir: path.resolve(projectRoot, 'src/presentation/client/public'),
   build: {
     outDir: path.resolve(projectRoot, 'build'),
@@ -68,8 +68,25 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: [path.resolve(projectRoot, 'tests/setup.ts')],
-    include: [path.resolve(projectRoot, 'src/**/*.test.{js,jsx,ts,tsx}')],
+    include: ['src/**/*.test.{js,jsx,ts,tsx}'],
     exclude: ['**/node_modules/**'],
+    coverage: {
+      all: true,
+      enabled: true,
+      provider: 'v8',
+      skipFull: true,
+      reportsDirectory: './coverage',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts', 'src/**/*.tsx'],
+      exclude: [
+        'src/main.tsx',
+        'src/**/*.test.ts',
+        'src/**/*.test.tsx',
+        'src/**/*.d.ts',
+        'src/**/index.ts',
+        'src/**/index.tsx',
+      ],
+    },
     deps: {
       optimizer: {
         web: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@typescript-eslint/eslint-plugin": "8.28.0",
         "@typescript-eslint/parser": "8.28.0",
         "@vitejs/plugin-react": "4.3.4",
+        "@vitest/coverage-v8": "^3.0.9",
         "@vitest/ui": "3.0.9",
         "eslint": "9.23.0",
         "eslint-config-prettier": "10.1.1",
@@ -405,6 +406,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bufbuild/protobuf": {
@@ -1509,6 +1520,16 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/expect-utils": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
@@ -1892,6 +1913,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@pkgr/core": {
@@ -3349,6 +3381,39 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.0.9.tgz",
+      "integrity": "sha512-15OACZcBtQ34keIEn19JYTVuMFTlFrClclwWjHo/IRPg/8ELpkgNTl0o7WLP9WO9XGH6+tip9CPYtEOrIDJvBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "debug": "^4.4.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.0.9",
+        "vitest": "3.0.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/expect": {
@@ -6368,6 +6433,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -6919,6 +6991,76 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -7367,6 +7509,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/make-dir": {
@@ -9582,6 +9736,82 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/test-exclude/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint:fix": "eslint --config config/eslint/eslint.config.js --fix .",
     "test:once": "vitest run --config config/vite/vite.config.ts",
     "test:watch": "vitest --config config/vite/vite.config.ts",
+    "test:coverage": "vitest run --config config/vite/vite.config.ts --coverage",
     "test:ui": "vitest --ui --config config/vite/vite.config.ts",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build"
@@ -55,6 +56,7 @@
     "@typescript-eslint/eslint-plugin": "8.28.0",
     "@typescript-eslint/parser": "8.28.0",
     "@vitejs/plugin-react": "4.3.4",
+    "@vitest/coverage-v8": "^3.0.9",
     "@vitest/ui": "3.0.9",
     "eslint": "9.23.0",
     "eslint-config-prettier": "10.1.1",

--- a/src/domain/primitives/NonEmptyString/NonEmptyString.factory.ts
+++ b/src/domain/primitives/NonEmptyString/NonEmptyString.factory.ts
@@ -4,9 +4,9 @@ import { Either, Left, Right } from '@utility/functional/monads';
 export function createNonEmptyString(
   value: string,
 ): Either<NonEmptyStringError, NonEmptyString> {
-  const isNonEmptyString = value.trim().length > 0;
+  const isEmpty = value === null || value === undefined || value.length === 0;
 
-  return isNonEmptyString ? Right(value as NonEmptyString) : Left(createNonEmptyStringError());
+  return isEmpty ? Left(createNonEmptyStringError()) : Right(value as NonEmptyString);
 }
 
 export function createNonEmptyStringError() {
@@ -14,5 +14,5 @@ export function createNonEmptyStringError() {
     code: 'NonEmptyStringError',
     reason: 'InvalidValue',
     message: 'NonEmptyString cannot contain an empty string',
-  }) as NonEmptyStringError;
+  } as const);
 }

--- a/src/domain/primitives/NonEmptyString/NonEmptyString.module.ts
+++ b/src/domain/primitives/NonEmptyString/NonEmptyString.module.ts
@@ -1,0 +1,8 @@
+import { createNonEmptyString } from './NonEmptyString.factory.ts';
+import { isNonEmptyString, toString } from './NonEmptyString.utils.ts';
+
+export const NonEmptyString = {
+  create: createNonEmptyString,
+  isNonEmptyString,
+  toString,
+} as const;

--- a/src/domain/primitives/NonEmptyString/NonEmptyString.test.ts
+++ b/src/domain/primitives/NonEmptyString/NonEmptyString.test.ts
@@ -1,13 +1,9 @@
-import { createNonEmptyString } from './NonEmptyString.factory.ts';
+import { NonEmptyString } from './NonEmptyString.types.ts';
+import { createNonEmptyString, createNonEmptyStringError } from './NonEmptyString.factory.ts';
+import { isNonEmptyString, toString } from './NonEmptyString.utils.ts';
 
 describe('NonEmptyString', () => {
   describe('createNonEmptyString', () => {
-    it('accepts a valid non-empty string', () => {
-      const result = createNonEmptyString('Mars');
-      expect(result.type).toBe('Right');
-      expect(result.value).toBe('Mars');
-    });
-
     it('rejects an empty string', () => {
       const result = createNonEmptyString('');
       expect(result.type).toBe('Left');
@@ -18,20 +14,66 @@ describe('NonEmptyString', () => {
       });
     });
 
-    it('rejects a whitespace-only string due to trim', () => {
+    it('accepts a valid non-empty string', () => {
+      const result = createNonEmptyString('Mars');
+      expect(result.type).toBe('Right');
+      expect(result.value).toBe('Mars');
+    });
+
+    it('accepts a whitespace-only string', () => {
       const result = createNonEmptyString('   ');
-      expect(result.type).toBe('Left');
-      expect(result.value).toEqual({
+      expect(result.type).toBe('Right');
+      expect(result.value).toBe('   ');
+    });
+
+    it('accepts a string with leading/trailing whitespace', () => {
+      const result = createNonEmptyString(' Sun ');
+      expect(result.type).toBe('Right');
+      expect(result.value).toBe(' Sun ');
+    });
+  });
+  describe('createNonEmptyStringError', () => {
+    it('creates an immutable error object with expected properties', () => {
+      const expectedError = createNonEmptyStringError();
+
+      expect(expectedError).toEqual({
         code: 'NonEmptyStringError',
         reason: 'InvalidValue',
         message: 'NonEmptyString cannot contain an empty string',
       });
     });
+    it('returns an immutable object', () => {
+      const expectedError = createNonEmptyStringError();
 
-    it('accepts a string with leading/trailing whitespace', () => {
-      const result = createNonEmptyString('  Sun  ');
-      expect(result.type).toBe('Right');
-      expect(result.value).toBe('  Sun  ');
+      expect(Object.isFrozen(expectedError)).toBe(true);
+    });
+  });
+  describe('utility functions', () => {
+    describe('isNonEmptyString', () => {
+      it('returns true for strings', () => {
+        expect(isNonEmptyString('Saturn')).toBe(true);
+      });
+
+      it('returns false for empty strings', () => {
+        expect(isNonEmptyString('')).toBe(false);
+      });
+
+      it('returns false for non-string types', () => {
+        expect(isNonEmptyString(undefined)).toBe(false);
+        expect(isNonEmptyString(null)).toBe(false);
+        expect(isNonEmptyString(true)).toBe(false);
+        expect(isNonEmptyString(42)).toBe(false);
+        expect(isNonEmptyString([])).toBe(false);
+        expect(isNonEmptyString({})).toBe(false);
+      });
+    });
+    describe('toString', () => {
+      it('returns the original value as a native string', () => {
+        const result = toString('Jupiter' as NonEmptyString);
+
+        expect(result).toEqual('Jupiter');
+        expect(typeof result).toBe('string');
+      });
     });
   });
 });

--- a/src/domain/primitives/NonEmptyString/NonEmptyString.types.ts
+++ b/src/domain/primitives/NonEmptyString/NonEmptyString.types.ts
@@ -1,9 +1,9 @@
-import { DomainError } from '@domain/types';
+import { Brand, DomainError } from '@domain/types';
+
+export type NonEmptyString = Brand<string, 'NonEmptyString'>;
 
 export type NonEmptyStringError = DomainError & {
   code: 'NonEmptyStringError';
   reason: 'InvalidValue';
-  message: 'message cannot be empty';
+  message: 'NonEmptyString cannot contain an empty string';
 };
-
-export type NonEmptyString = string & { readonly _tag: unique symbol };

--- a/src/domain/primitives/NonEmptyString/NonEmptyString.utils.ts
+++ b/src/domain/primitives/NonEmptyString/NonEmptyString.utils.ts
@@ -1,0 +1,6 @@
+import { NonEmptyString } from './NonEmptyString.types.ts';
+
+export const isNonEmptyString = (value: unknown): value is NonEmptyString =>
+  typeof value === 'string' && value !== '';
+
+export const toString = (value: NonEmptyString): string => value as string;

--- a/src/domain/types/Brand/Brand.type.ts
+++ b/src/domain/types/Brand/Brand.type.ts
@@ -1,0 +1,3 @@
+export type Brand<K, T> = K & {
+  __brand: T;
+};

--- a/src/domain/types/index.ts
+++ b/src/domain/types/index.ts
@@ -1,1 +1,2 @@
+export type { Brand } from './Brand/Brand.type.ts';
 export type { DomainError } from './DomainError/DomainError.interface.ts';

--- a/src/domain/values/Mass/Mass.test.ts
+++ b/src/domain/values/Mass/Mass.test.ts
@@ -70,7 +70,7 @@ describe('Mass', () => {
     });
 
     it('should reject invalid unit', () => {
-      const result = validateMass(1, 'kg' as any);
+      const result = validateMass(1, 'kilogram');
       expect(result.type).toBe('Left');
       if (result.type === 'Left') {
         expect(result.value).toEqual(createMassError('InvalidUnit'));
@@ -114,7 +114,7 @@ describe('Mass', () => {
     });
 
     it('should reject invalid unit', () => {
-      const result = createMass(1, 'kg' as any);
+      const result = createMass(1, 'kilogram');
       expect(result.type).toBe('Left');
       if (result.type === 'Left') {
         expect(result.value).toEqual(createMassError('InvalidUnit'));

--- a/src/domain/values/Mass/Mass.test.ts
+++ b/src/domain/values/Mass/Mass.test.ts
@@ -70,7 +70,8 @@ describe('Mass', () => {
     });
 
     it('should reject invalid unit', () => {
-      const result = validateMass(1, 'kilogram');
+      const invalidUnit = 'unknown unit' as never;
+      const result = validateMass(1, invalidUnit);
       expect(result.type).toBe('Left');
       if (result.type === 'Left') {
         expect(result.value).toEqual(createMassError('InvalidUnit'));
@@ -114,7 +115,8 @@ describe('Mass', () => {
     });
 
     it('should reject invalid unit', () => {
-      const result = createMass(1, 'kilogram');
+      const invalidUnit = 'unknown unit' as never;
+      const result = createMass(1, invalidUnit);
       expect(result.type).toBe('Left');
       if (result.type === 'Left') {
         expect(result.value).toEqual(createMassError('InvalidUnit'));


### PR DESCRIPTION
- make Vitest coverage work and create test:coverage script
- refactor NonEmptyString to use a module pattern
- create placeholder for TrimmedString primitive
- update NonEmptyString test; squash Typescript complaints